### PR TITLE
Second timed & windowed acceleration stream

### DIFF
--- a/src/main/resources/settings.conf
+++ b/src/main/resources/settings.conf
@@ -1,7 +1,7 @@
 ioft.spark.config.master = "local[2]"
 ioft.spark.config.appName = "Drone stream sample"
 
-ioft.spark.streaming.batchDuration = 5
+ioft.spark.streaming.batchDuration = 1
 
 ioft.es.source.host = "localhost"
 ioft.es.source.port = 7891

--- a/src/main/scala/com/stratio/ioft/StreamDriver.scala
+++ b/src/main/scala/com/stratio/ioft/StreamDriver.scala
@@ -36,7 +36,7 @@ object StreamDriver extends App with IOFTConfig {
     parse(json).extract[Entry]
   }
 
-  val accelStream = accelerationStream(entriesStream)
+  val accelStream = accelerationStream(entriesStream.window(Seconds(5), Seconds(5)))
 
   val bumpStream = averageOutlierBumpDetector(accelStream.map {case (ts, (x,y,z)) => ts -> z }, 5.0)
   //val bumpStream = naiveBumpDetector(accelStream)

--- a/src/main/scala/com/stratio/ioft/StreamDriver.scala
+++ b/src/main/scala/com/stratio/ioft/StreamDriver.scala
@@ -26,19 +26,21 @@ object StreamDriver extends App with IOFTConfig {
 
   //sc.sparkContext.setLogLevel("ERROR")
 
-  val rawInputStream = sc.socketTextStream(sourceConfig.getString("host"), sourceConfig.getInt("port"))
+  val droneId: DroneIdType = "drone01"
+
+  val rawInputStream = sc.socketTextStream(
+    sourceConfig.getString("host"), sourceConfig.getInt("port")
+  ) map (json => droneId -> json)
 
   // Extract case class instances from the input text
 
   implicit val formats = DefaultFormats ++ librePilotSerializers
 
-  val entriesStream = rawInputStream.map { json =>
-    parse(json).extract[Entry]
-  }
+  val entriesStream = rawInputStream.mapValues(parse(_).extract[Entry])
 
   val accelStream = accelerationStream(entriesStream.window(Seconds(5), Seconds(5)))
 
-  val bumpStream = averageOutlierBumpDetector(accelStream.map {case (ts, (x,y,z)) => ts -> z }, 5.0)
+  val bumpStream = averageOutlierBumpDetector(accelStream.mapValues { case (ts, (x,y,z)) => ts -> z }, 5.0)
   //val bumpStream = naiveBumpDetector(accelStream)
 
   bumpStream.foreachRDD(_.foreach(x => println(s"PEAK!!$x")))


### PR DESCRIPTION
This PR reduces the batch interval to 1 second. This way, each drone state can be fully monitored. However, acceleration changes for  bump detection requires 5s windows. Those windows are generated by the stateful DStream operation `window` which is called using window size and sliding window of 5 seconds each.

On the other hand, we are supposed to be managing a swarm (drone fleet) so the drone identification should form part of each event key. Thus enabling per drone state monitoring and analysis.
